### PR TITLE
Add neutron from rdo-management

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -92,6 +92,10 @@ packages:
   conf: core
   maintainers:
   - jslagle@redhat.com
+- project: neutron
+  conf: core
+  maintainers:
+  - jslagle@redhat.com
 # The openstack clients
 - project: novaclient
   conf: client


### PR DESCRIPTION
We need to carry this revert:
https://review.openstack.org/#/c/156853

Otherwise, PXE booting via Ironic is broken.
